### PR TITLE
entry date for fulltext filtering

### DIFF
--- a/xreport/reports.py
+++ b/xreport/reports.py
@@ -303,7 +303,8 @@ class FullTextReport(Report):
         """
         for journal in self.journals:
             # The ADS query to retrieve all records with full text for a given journal
-            query = 'bibstem:"{0}" fulltext_mtime:["1000-01-01t00:00:00.000Z" TO *]'.format(journal)
+            # The entry date filter is to allow for a lag in the indexing of full text
+            query = 'bibstem:"{0}" fulltext_mtime:["1000-01-01t00:00:00.000Z" TO *] entdate:[* TO NOW-30DAYS]'.format(journal)
             # The query populates a dictionary keyed on volume number, listing the number of records per volume
             full_dict = _get_facet_data(self.config, query, 'volume')
             # Coverage data is stored in a dictionary
@@ -358,7 +359,7 @@ class FullTextReport(Report):
         for journal in ['SpWea']:
             # The ADS query to retrieve all records without full text for a given journal
             # Additional filter: records entered up to one month from now
-            query = 'bibstem:"{0}"  -fulltext_mtime:["1000-01-01t00:00:00.000Z" TO *]  entdate:[* TO NOW-30DAYS]'.format(journal)
+            query = 'bibstem:"{0}"  -fulltext_mtime:["1000-01-01t00:00:00.000Z" TO *] entdate:[* TO NOW-30DAYS]'.format(journal)
             missing_pubs = _get_records(self.config, query, 'bibcode,doi,title,first_author_norm,volume,issue')
             self.missing[journal] = missing_pubs
 


### PR DESCRIPTION
When retrieving records with full text, get those that were entered up to one month before current date, to allow to a lag in indexing of full text (to avoid reporting seemingly missing full text that's actually in the process of being added)