### PR TITLE
updated record query

### DIFF
--- a/xreport/reports.py
+++ b/xreport/reports.py
@@ -195,7 +195,7 @@ class Report(object):
         """
         for journal in self.journals:
             # First get the number of records per volume
-            query = 'bibstem:"{0}"'.format(journal)
+            query = 'bibstem:"{0}" doctype:article'.format(journal)
             # Get the data using a facet query
             art_dict = _get_facet_data(self.config, query, 'volume')
             # Also, get the number of records per year


### PR DESCRIPTION
The filter `doctype:article` was added to the general record query. For all coverage reports we only consider records of this doctype.