### PR TITLE
Add reference coverage report

### DIFF
--- a/config.py
+++ b/config.py
@@ -16,6 +16,8 @@ ADS_FULLTEXT_DATA = "/fulltext/stats"
 ADS_METADATA_DATA = "/metadata/stats"
 ADS_REFERENCE_STATS_YEAR = "refcounts_aggr_by_year.tsv"
 ADS_REFERENCE_STATS_VOLUME = "refcounts_aggr_by_volume.tsv"
+ADS_REFCOVERAGE_STATS_YEAR = "refcoverage_aggr_by_year.tsv"
+ADS_REFCOVERAGE_STATS_VOLUME = "refcoverage_aggr_by_volume.tsv"
 ADS_FULLTEXT_STATS_YEAR = "fulltext_year_aggr.tsv"
 ADS_FULLTEXT_STATS_VOLUME = "fulltext_volume_aggr.tsv"
 ADS_METADATA_STATS_YEAR = "records_agg_year.tsv"
@@ -40,8 +42,8 @@ COLLECTIONS = list(TOPIC_SETS.keys()) + list(CORE_COLLECTIONS.keys())
 # Report formats supported
 FORMATS = ['general', 'curators', 'missing']
 # Report types supported
-SUBJECTS = ['FULLTEXT', 'REFERENCES', 'SUMMARY', 'METADATA', 'ALL']
-TOPIC_SUBJECTS = ['FULLTEXT', 'REFERENCES', 'METADATA']
+SUBJECTS = ['FULLTEXT', 'REFERENCES', 'SUMMARY', 'METADATA', 'REFCOVERAGE', 'ALL']
+TOPIC_SUBJECTS = ['FULLTEXT', 'REFERENCES', 'METADATA', 'REFCOVERAGE']
 # Which journals are we reporting on per collection
 JOURNALS = {
     'CORE_AST':['A&A','A&ARv','A&AS','AJ','AN','APh','ApJ','ApJL','ApJS','ARA&A','NatAs','PASP'],

--- a/run.py
+++ b/run.py
@@ -72,7 +72,7 @@ if __name__ == '__main__':
         sys.exit('The "curators" format only supports the "fulltext" report')
     if args.all:
         for coll in config.get('COLLECTIONS'):
-            for subject in ['FULLTEXT', 'REFERENCES','METADATA']:
+            for subject in ['FULLTEXT', 'REFERENCES', 'METADATA', 'REFCOVERAGE']:
                 try:
                     report = tasks.create_report(collection=coll, format=args.format, subject=subject, use_year=use_year)
                 except:

--- a/scripts/aggregate_refcoverage_stats.py
+++ b/scripts/aggregate_refcoverage_stats.py
@@ -1,0 +1,53 @@
+import os
+import sys
+import pandas as pd
+
+ref_base = '/proj/ads/abstracts/stats/references'
+meta_base = '/proj/ads/abstracts/stats/metadata'
+
+# Input: records with any references (bibcode, max_ref_count from publisher or Crossref)
+references_counts_file = '{0}/references.counts.tsv'.format(ref_base)
+# Input: total record counts per bibstem/year and bibstem/volume
+records_year_file = '{0}/records_agg_year.tsv'.format(meta_base)
+records_volume_file = '{0}/records_agg_volume.tsv'.format(meta_base)
+# Output files
+agg_by_year_res = '{0}/refcoverage_aggr_by_year.tsv'.format(ref_base)
+agg_by_volume_res = '{0}/refcoverage_aggr_by_volume.tsv'.format(ref_base)
+
+# Read bibcodes with references (one row per bibcode with refs)
+df = pd.read_csv(references_counts_file, sep='\t', header=None, names=['bibcode', 'ref_count'])
+# Extract year, bibstem, volume, letter from bibcodes
+pattern = r'^(\d{4})(.{5})(.{4})(.)'
+df[['year', 'bibstem', 'volume', 'letter']] = df['bibcode'].str.extract(pattern)
+# Remove periods from bibstems
+df['bibstem'] = df['bibstem'].str.replace('.', '', regex=False)
+# Remove periods from volumes
+df['volume'] = df['volume'].str.replace('.', '', regex=False)
+# Replace ApJ with ApJL for ApJ Letter papers
+condition1 = (df['bibstem'] == 'ApJ')
+condition2 = (df['letter'] == 'L')
+df.loc[condition1 & condition2, 'bibstem'] = 'ApJL'
+# Store years as integers
+df['year'] = df['year'].astype(int)
+# Store volumes as numeric, coerce non-numeric entries (e.g. 'tmp') to NaN
+df['volume'] = pd.to_numeric(df['volume'], errors='coerce')
+df = df.dropna(subset=['volume'])
+df['volume'] = df['volume'].astype(int)
+
+# Count records with refs per bibstem+year and per bibstem+volume
+aggr_by_year = df.groupby(['bibstem', 'year']).size().reset_index(name='ref_count')
+aggr_by_volume = df.groupby(['bibstem', 'volume']).size().reset_index(name='ref_count')
+
+# Read total record counts from metadata stats
+records_year = pd.read_csv(records_year_file, sep='\t')
+records_volume = pd.read_csv(records_volume_file, sep='\t')
+# Remove periods from bibstems in the metadata stats files
+records_year['bibstem'] = records_year['bibstem'].str.replace('.', '', regex=False)
+records_volume['bibstem'] = records_volume['bibstem'].str.replace('.', '', regex=False)
+
+# Inner join: only keep bibstem+year/volume entries where references exist
+year_merged = pd.merge(records_year, aggr_by_year, on=['bibstem', 'year'])
+year_merged.to_csv(agg_by_year_res, sep='\t', index=False)
+
+volume_merged = pd.merge(records_volume, aggr_by_volume, on=['bibstem', 'volume'])
+volume_merged.to_csv(agg_by_volume_res, sep='\t', index=False)

--- a/xreport/reports.py
+++ b/xreport/reports.py
@@ -705,6 +705,63 @@ class ReferenceMatchingReport(Report):
             res_dict = dict(zip(results[key_column], results['fraction']))
             self.statsdata[journal]['general'] = {str(key): value for key, value in res_dict.items()}
 
+class ReferenceCoverageReport(Report):
+    """
+    Report showing the percentage of records for which references are available
+    from the publisher or Crossref
+    """
+    def __init__(self, config={}):
+        super(ReferenceCoverageReport, self).__init__(config=config)
+
+    def make_report(self, collection, report_type):
+        """
+        param: collection: collection of publications to create report for
+        param: report_type: specification of report type
+        """
+        super(ReferenceCoverageReport, self).make_report(collection, report_type)
+        self._get_refcoverage_data()
+
+    def save_report(self, collection, report_type, subject):
+        """
+        Save the data created in the make_report method in Excel format
+
+        param: collection: collection of publications to create report for
+        param: report_type: specification of report type
+        param: subject: specification of type data to create report for
+        """
+        super(ReferenceCoverageReport, self).save_report(collection, report_type, subject)
+
+    def _get_refcoverage_data(self):
+        """
+        For a set of journals, get the fraction of records with references available
+        (from publisher or Crossref) by volume or year
+        """
+        if self.use_year:
+            data_file = "{0}/{1}".format(self.config['ADS_REFERENCE_DATA'], self.config['ADS_REFCOVERAGE_STATS_YEAR'])
+            field = 'year'
+        else:
+            data_file = "{0}/{1}".format(self.config['ADS_REFERENCE_DATA'], self.config['ADS_REFCOVERAGE_STATS_VOLUME'])
+            field = 'volume'
+        df = pd.read_csv(data_file, sep='\t')
+        first_col = df.columns[0]
+        df[first_col] = df[first_col].astype(str).str.replace('.', '', regex=False)
+        df = df[df['bibstem'].isin(self.journals)]
+        df[field] = df[field].astype(int)
+        df[field] = df[field].astype(str)
+        for journal in self.journals:
+            cov_dict = {}
+            for kk in sorted(self.statsdata[journal]['pubdata'].keys()):
+                cov_dict[str(kk)] = 0.0
+            try:
+                jdata = df[df['bibstem'] == journal]
+                fractions = jdata['ref_count'] / jdata['record_count']
+                fractions = np.where(np.isinf(fractions), 0, fractions)
+                cov_dict = dict(zip(jdata[field], fractions))
+            except Exception:
+                pass
+            self.statsdata[journal]['general'] = cov_dict
+
+
 class MetaDataReport(Report):
     """
     Create metadata completeness report 

--- a/xreport/tasks.py
+++ b/xreport/tasks.py
@@ -5,6 +5,7 @@ from builtins import str
 import xreport.app as app_module
 from xreport.reports import FullTextReport
 from xreport.reports import ReferenceMatchingReport
+from xreport.reports import ReferenceCoverageReport
 from xreport.reports import MetaDataReport
 from xreport.reports import SummaryReport
 # ============================= INITIALIZATION ==================================== #
@@ -78,6 +79,19 @@ def create_report(**args):
             mreport.save_report(collection, report_format, subject)
         except Exception as err:
             msg = "Error saving metadata report for collection '{0}' in format '{1}': {2}".format(collection, report_format, err)
+            logger.error(msg)
+    if subject in ['REFCOVERAGE', 'ALL']:
+        rcreport = ReferenceCoverageReport()
+        rcreport.use_year = use_year
+        try:
+            rcreport.make_report(collection, 'general')
+        except Exception as err:
+            msg = "Error making reference coverage report for collection '{0}' in format '{1}': {2}".format(collection, report_format, err)
+            logger.error(msg)
+        try:
+            rcreport.save_report(collection, 'general', subject)
+        except Exception as err:
+            msg = "Error saving reference coverage report for collection '{0}' in format '{1}': {2}".format(collection, report_format, err)
             logger.error(msg)
     if subject == 'SUMMARY':
         # Create a summarizing report

--- a/xreport/tests/data/refcoverage_aggr_by_year.tsv
+++ b/xreport/tests/data/refcoverage_aggr_by_year.tsv
@@ -1,0 +1,5 @@
+bibstem	year	record_count	ref_count
+ApJ	2012	189	170
+ApJ	2015	186	178
+ApJ	2020	196	190
+MNRAS	2020	196	185

--- a/xreport/tests/test_reports.py
+++ b/xreport/tests/test_reports.py
@@ -12,6 +12,7 @@ import pandas as pd
 from xreport.reports import Report
 from xreport.reports import FullTextReport
 from xreport.reports import ReferenceMatchingReport
+from xreport.reports import ReferenceCoverageReport
 from xreport.reports import SummaryReport
 
 class TestMethods(unittest.TestCase):
@@ -170,6 +171,35 @@ class TestMethods(unittest.TestCase):
         # Create the report using mock data
         rmr.make_report('AST', 'REFERENCES')
         self.assertEqual(rmr.statsdata['ApJ..']['publisher'][900], 96.7)
+
+        ######## TEST OF THE REFERENCE COVERAGE REPORT CLASS ###############################
+
+        rcr = ReferenceCoverageReport()
+        # Set the minimum state needed to test _get_refcoverage_data directly
+        rcr.use_year = True
+        rcr.journals = ['ApJ', 'MNRAS']
+        rcr.statsdata = {
+            'ApJ': {
+                'pubdata': {2012: 189, 2015: 186, 2020: 196},
+                'general': {}, 'arxiv': {}, 'publisher': {}, 'crossref': {}
+            },
+            'MNRAS': {
+                'pubdata': {2020: 196},
+                'general': {}, 'arxiv': {}, 'publisher': {}, 'crossref': {}
+            }
+        }
+        rcr.config['ADS_REFERENCE_DATA'] = '{0}/xreport/tests/data'.format(self.proj_home)
+        rcr.config['ADS_REFCOVERAGE_STATS_YEAR'] = 'refcoverage_aggr_by_year.tsv'
+        rcr._get_refcoverage_data()
+        # Fraction for ApJ 2020: 190 / 196
+        expected_frac_apj_2020 = round(190 / 196, 4)
+        self.assertAlmostEqual(rcr.statsdata['ApJ']['general']['2020'], expected_frac_apj_2020, places=3)
+        # Fraction for ApJ 2012: 170 / 189
+        expected_frac_apj_2012 = round(170 / 189, 4)
+        self.assertAlmostEqual(rcr.statsdata['ApJ']['general']['2012'], expected_frac_apj_2012, places=3)
+        # Fraction for MNRAS 2020: 185 / 196
+        expected_frac_mnras_2020 = round(185 / 196, 4)
+        self.assertAlmostEqual(rcr.statsdata['MNRAS']['general']['2020'], expected_frac_mnras_2020, places=3)
 
         ######## TEST OF THE SUMMARY REPORT CLASS ###############################
         sr = SummaryReport()


### PR DESCRIPTION
New REFCOVERAGE report showing the percentage of records that have references available from publisher or Crossref, analogous to the fulltext coverage report. Includes aggregation script, config keys, ReferenceCoverageReport class, task wiring, and test data.