### PR TITLE
Add --no-drive option to skip Google Drive upload

### DIFF
--- a/run.py
+++ b/run.py
@@ -46,6 +46,8 @@ if __name__ == '__main__':
                         help='Run all reports on all special topics')
     parser.add_argument('-l', '--list', action='store_true',
                         help='List of all collections')
+    parser.add_argument('-n', '--no-drive', action='store_true', dest='no_drive',
+                        help='Skip uploading reports to Google Drive')
     args = parser.parse_args()
 
     # Determine the type of reporting: by volume or by year. If by year, set the start year
@@ -74,7 +76,7 @@ if __name__ == '__main__':
         for coll in config.get('COLLECTIONS'):
             for subject in ['FULLTEXT', 'REFERENCES', 'METADATA', 'REFCOVERAGE']:
                 try:
-                    report = tasks.create_report(collection=coll, format=args.format, subject=subject, use_year=use_year)
+                    report = tasks.create_report(collection=coll, format=args.format, subject=subject, use_year=use_year, no_drive=args.no_drive)
                 except:
                     logger.error('Creating "{0}" report for "{1}" on collection "{2}" failed: {3}'.format(subject, args.format, coll, error))
                     sys.exit('Creating "{0}" report for "{1}" on collection "{2}" failed: {3}'.format(subject, args.format, coll, error))
@@ -82,20 +84,20 @@ if __name__ == '__main__':
         for coll, name in config.get('TOPIC_SETS').items():
             if args.format.lower() != 'curators':
                 try:
-                    report = tasks.create_report(collection=coll, format="general", subject=args.subject, use_year=use_year)
+                    report = tasks.create_report(collection=coll, format="general", subject=args.subject, use_year=use_year, no_drive=args.no_drive)
                 except Exception as error:
                     logger.error('Creating "{0}" report for "{1}" on collection "{2}" failed: {3}'.format(args.subject, "general", coll, error))
                     sys.exit('Creating "{0}" report for "{1}" on collection "{2}" failed: {3}'.format(args.subject, "general", coll, error))
             else:
                  try:
-                     report = tasks.create_report(collection=coll, format="CURATORS", subject="FULLTEXT", use_year=use_year)
+                     report = tasks.create_report(collection=coll, format="CURATORS", subject="FULLTEXT", use_year=use_year, no_drive=args.no_drive)
                  except:
                      logger.error('Creating "{0}" report for "{1}" on collection "{2}" failed: {3}'.format(subject, "CURATORS", coll, error))
                      sys.exit('Creating "{0}" report for "{1}" on collection "{2}" failed: {3}'.format(subject, "CURATORS", coll, error))
     else:
         try:
             coll = collmap.get(args.collection, args.collection)
-            report = tasks.create_report(collection=coll, format=args.format, subject=args.subject, use_year=use_year)
+            report = tasks.create_report(collection=coll, format=args.format, subject=args.subject, use_year=use_year, no_drive=args.no_drive)
         except Exception as error:
             logger.error('Creating "{0}" report for "{1}" on collection "{2}" failed: {3}'.format(args.subject, args.format, args.collection, error))
             sys.exit('Creating "{0}" report for "{1}" on collection "{2}" failed: {3}'.format(args.subject, args.format, args.collection, error))

--- a/xreport/reports.py
+++ b/xreport/reports.py
@@ -224,10 +224,11 @@ class Report(object):
                     res = _add_hyperlinks(output_file)
                 except Exception as err:
                     self.logger.error("Failed to add hyperlinks to fulltext report {0}: {1}".format(output_file, err))
-            try:
-                res = _upload_to_teamdrive(collection,subject.lower(),output_file)
-            except Exception as err:
-                self.logger.error("Failed to upload report {0} to Team Drive: {1}".format(os.path.basename(output_file), err))
+            if not self.config.get('NO_DRIVE', False):
+                try:
+                    res = _upload_to_teamdrive(collection,subject.lower(),output_file)
+                except Exception as err:
+                    self.logger.error("Failed to upload report {0} to Team Drive: {1}".format(os.path.basename(output_file), err))
     #
     def save_missing(self, collection, report_type, subject):
         """

--- a/xreport/tasks.py
+++ b/xreport/tasks.py
@@ -26,10 +26,13 @@ def create_report(**args):
     subject = args['subject']
     # Do we report by volume or year?
     use_year = args['use_year']
+    # Skip Google Drive upload?
+    no_drive = args.get('no_drive', False)
     #
     if subject in ['FULLTEXT', 'ALL']:
         # Initialize the class for full text reporting
         ftreport = FullTextReport()
+        ftreport.config['NO_DRIVE'] = no_drive
         # Set the reporting type
         ftreport.use_year = use_year
         # The first step consists of retrieving and preparing the data to generate the report
@@ -53,6 +56,7 @@ def create_report(**args):
         rmreport = ReferenceMatchingReport()
         # Set the reporting type
         rmreport.use_year = use_year
+        rmreport.config['NO_DRIVE'] = no_drive
         try:
             rmreport.make_report(collection, 'general')
         except Exception as err:
@@ -69,6 +73,7 @@ def create_report(**args):
         mreport = MetaDataReport()
         # Set the reporing type
         mreport.use_year = use_year
+        mreport.config['NO_DRIVE'] = no_drive
         try:
             mreport.make_report(collection, 'general')
         except Exception as err:
@@ -83,6 +88,7 @@ def create_report(**args):
     if subject in ['REFCOVERAGE', 'ALL']:
         rcreport = ReferenceCoverageReport()
         rcreport.use_year = use_year
+        rcreport.config['NO_DRIVE'] = no_drive
         try:
             rcreport.make_report(collection, 'general')
         except Exception as err:
@@ -98,6 +104,7 @@ def create_report(**args):
         summary = SummaryReport()
         # Set the reporting type
         summary.use_year = use_year
+        summary.config['NO_DRIVE'] = no_drive
         try:
             summary.make_report(collection, report_format)
         except Exception as err:


### PR DESCRIPTION
New -n/--no-drive flag generates Excel reports locally without uploading them to Google Drive. Useful for testing or when running in environments without Drive access.