### PR TITLE
Remove obsolete per-type data directory and stats filename config var…

### DIFF
--- a/config.py
+++ b/config.py
@@ -11,20 +11,9 @@ CLASSIC_USAGE_INDEX = {
     'reads':'/tmp/reads.links',
     'downloads':'/tmp/downloads.links'
 }
-ADS_REFERENCE_DATA = "/references/stats"
-ADS_FULLTEXT_DATA = "/fulltext/stats"
-ADS_METADATA_DATA = "/metadata/stats"
 ADS_STATS_DATA = "/stats"
 ADS_RECORD_STATS_YEAR = "records_agg_year.tsv"
 ADS_RECORD_STATS_VOLUME = "records_agg_volume.tsv"
-ADS_REFERENCE_STATS_YEAR = "refcounts_aggr_by_year.tsv"
-ADS_REFERENCE_STATS_VOLUME = "refcounts_aggr_by_volume.tsv"
-ADS_REFCOVERAGE_STATS_YEAR = "refcoverage_aggr_by_year.tsv"
-ADS_REFCOVERAGE_STATS_VOLUME = "refcoverage_aggr_by_volume.tsv"
-ADS_FULLTEXT_STATS_YEAR = "fulltext_year_aggr.tsv"
-ADS_FULLTEXT_STATS_VOLUME = "fulltext_volume_aggr.tsv"
-ADS_METADATA_STATS_YEAR = "records_agg_year.tsv"
-ADS_METADATA_STATS_VOLUME = "records_agg_volume.tsv"
 ADS_PUBLISHER_DATA = "/config/publisher_bibstem.dat"
 ADS_COMPLETENESS_DATA = "/config/completeness_export.json"
 ADS_BIBSTEMS = "bibstems.dat"

--- a/xreport/tests/test_reports.py
+++ b/xreport/tests/test_reports.py
@@ -67,7 +67,7 @@ class TestMethods(unittest.TestCase):
         # Confirm that the date string in the class is today's date
         self.assertEqual(r.dstring, datetime.today().strftime('%Y%m%d'))
         # We expect the following keys in the configuration dictionary
-        expected_config_keys = ['PROJ_HOME', 'ADS_API_TOKEN', 'ADS_API_URL', 'ADS_REFERENCE_DATA', 'CLASSIC_FULLTEXT_INDEX',
+        expected_config_keys = ['PROJ_HOME', 'ADS_API_TOKEN', 'ADS_API_URL', 'CLASSIC_FULLTEXT_INDEX',
                                 'CLASSIC_USAGE_INDEX', 'COLLECTIONS', 'COLLECTION_FILTERS', 'CONTENT_QUERIES', 'FORMATS', 
                                 'JOURNALS', 'LOGGING_LEVEL', 'LOG_STDOUT', 'OUTPUT_DIRECTORY', 'SKIP_USAGE', 'SOURCES', 
                                 'SUBJECTS', 'YEAR_IS_VOL']
@@ -162,11 +162,7 @@ class TestMethods(unittest.TestCase):
 
         ######## TEST OF THE REFERENCES REPORT CLASS ###############################
 
-        config = {
-            'ADS_REFERENCE_DATA':'{0}/xreport/tests/data/references'.format(self.proj_home)
-        }
-
-        rmr = ReferenceMatchingReport(config=config)
+        rmr = ReferenceMatchingReport()
         rmr.config['JOURNALS']['AST'] = ['ApJ..']
         # Create the report using mock data
         rmr.make_report('AST', 'REFERENCES')


### PR DESCRIPTION
…iables

ADS_REFERENCE_DATA, ADS_FULLTEXT_DATA, ADS_METADATA_DATA and the eight old per-type stats filenames (ADS_REFERENCE_STATS_*, ADS_REFCOVERAGE_STATS_*, ADS_FULLTEXT_STATS_*, ADS_METADATA_STATS_*) are no longer read anywhere after the consolidated stats migration; remove them from config and local_config. Update test expected_config_keys and stale ReferenceMatchingReport test setup accordingly.