### PR TITLE
Replace adsputils with a minimal local implementation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 pip==23.2.1
 setuptools==44.1.1
-adsputils==1.4.3
 git+https://github.com/adsabs/ADSGoogleConnector.git@v0.0.6
 Jinja2==3.1.1
 openpyxl==3.0.9

--- a/run.py
+++ b/run.py
@@ -11,7 +11,7 @@ warnings.simplefilter(action='ignore', category=FutureWarning)
 
 # ============================= INITIALIZATION ==================================== #
 
-from adsputils import setup_logging, load_config
+from xreport.compat import setup_logging, load_config
 proj_home = os.path.realpath(os.path.dirname(__file__))
 config = load_config(proj_home=proj_home)
 logger = setup_logging('run.py', proj_home=proj_home,

--- a/xreport/app.py
+++ b/xreport/app.py
@@ -1,5 +1,0 @@
-from adsputils import ADSCelery
-
-class xreport(ADSCelery):
-    def attempt_recovery(self, task, args=None, kwargs=None, einfo=None, retval=None):
-        pass

--- a/xreport/compat.py
+++ b/xreport/compat.py
@@ -1,0 +1,50 @@
+import os
+import sys
+import logging
+
+
+def load_config(proj_home=None):
+    """
+    Load configuration from config.py, optionally overridden by local_config.py.
+    Both files are looked up in proj_home. Uppercase-named variables are extracted.
+    """
+    if proj_home is None:
+        proj_home = os.path.realpath(os.path.dirname(__file__))
+
+    config = {'PROJ_HOME': proj_home}
+
+    added_to_path = proj_home not in sys.path
+    if added_to_path:
+        sys.path.insert(0, proj_home)
+
+    try:
+        for fname in ('config.py', 'local_config.py'):
+            fpath = os.path.join(proj_home, fname)
+            if os.path.exists(fpath):
+                namespace = {}
+                with open(fpath) as f:
+                    exec(compile(f.read(), fpath, 'exec'), namespace)
+                for key, value in namespace.items():
+                    if key.isupper():
+                        config[key] = value
+    finally:
+        if added_to_path and proj_home in sys.path:
+            sys.path.remove(proj_home)
+
+    return config
+
+
+def setup_logging(name, proj_home=None, level='INFO', attach_stdout=False):
+    """
+    Return a logger for the given name, adding a handler the first time it is called.
+    """
+    logger = logging.getLogger(name)
+    logger.setLevel(getattr(logging, level.upper(), logging.INFO))
+    if not logger.handlers:
+        handler = logging.StreamHandler(sys.stdout if attach_stdout else sys.stderr)
+        handler.setFormatter(logging.Formatter(
+            '%(asctime)s %(levelname)s %(name)s - %(message)s',
+            datefmt='%Y-%m-%d %H:%M:%S'
+        ))
+        logger.addHandler(handler)
+    return logger

--- a/xreport/reports.py
+++ b/xreport/reports.py
@@ -28,7 +28,7 @@ class Report(object):
         Initializes the class
         """
         # ============================= INITIALIZATION ==================================== #
-        from adsputils import setup_logging, load_config
+        from xreport.compat import setup_logging, load_config
         proj_home = os.path.realpath(os.path.join(os.path.dirname(__file__), '../'))
         self.config = load_config(proj_home=proj_home)
         if config:

--- a/xreport/tasks.py
+++ b/xreport/tasks.py
@@ -1,21 +1,18 @@
-from __future__ import absolute_import, unicode_literals
 import os
 import sys
-from builtins import str
-import xreport.app as app_module
 from xreport.reports import FullTextReport
 from xreport.reports import ReferenceMatchingReport
 from xreport.reports import ReferenceCoverageReport
 from xreport.reports import MetaDataReport
 from xreport.reports import SummaryReport
+from xreport.compat import setup_logging, load_config
 # ============================= INITIALIZATION ==================================== #
-
-from adsputils import setup_logging, load_config
 
 proj_home = os.path.realpath(os.path.join(os.path.dirname(__file__), '../'))
 config = load_config(proj_home=proj_home)
-app = app_module.xreport('ads-expansion-reporting', proj_home=proj_home, local_config=globals().get('local_config', {}))
-logger = app.logger
+logger = setup_logging(__name__, proj_home=proj_home,
+                       level=config.get('LOGGING_LEVEL', 'INFO'),
+                       attach_stdout=config.get('LOG_STDOUT', False))
 # ============================= FUNCTIONS ========================================= #
 def create_report(**args):
     # What is the report format

--- a/xreport/tests/test_reports.py
+++ b/xreport/tests/test_reports.py
@@ -19,7 +19,7 @@ class TestMethods(unittest.TestCase):
 
     '''Check if methods return expected results'''
     def setUp(self):
-        from adsputils import load_config
+        from xreport.compat import load_config
         self.proj_home = os.path.realpath(os.path.join(os.path.dirname(__file__), '../../'))
         self.config = load_config(proj_home=self.proj_home)
 

--- a/xreport/tests/test_utils.py
+++ b/xreport/tests/test_utils.py
@@ -15,7 +15,7 @@ class TestMethods(unittest.TestCase):
 
     '''Check if methods return expected results'''
     def setUp(self):
-        from adsputils import load_config
+        from xreport.compat import load_config
         self.proj_home = os.path.realpath(os.path.join(os.path.dirname(__file__), '../../'))
         self.config = load_config(proj_home=self.proj_home)
     

--- a/xreport/utils.py
+++ b/xreport/utils.py
@@ -13,7 +13,7 @@ from openpyxl.styles import Font
 from urllib.parse import urlencode, urlunparse
 # ============================= INITIALIZATION ==================================== #
 
-from adsputils import setup_logging, load_config
+from xreport.compat import setup_logging, load_config
 
 proj_home = os.path.realpath(os.path.join(os.path.dirname(__file__), '../'))
 config = load_config(proj_home=proj_home)


### PR DESCRIPTION
adsputils pulls in Celery and related dependencies that cause deployment problems. Since only load_config and setup_logging are used (no Celery tasks), replace them with a small xreport/compat.py:

- load_config(proj_home): reads config.py then overlays local_config.py, extracting uppercase-named variables into a plain dict
- setup_logging(name, ...): thin wrapper around stdlib logging

Remove xreport/app.py (ADSCelery stub with no callers after tasks.py cleanup). Update all import sites and remove adsputils from requirements.txt.